### PR TITLE
WL-3756 : Make the default review score for a re-submission the same as for a new submission

### DIFF
--- a/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -5576,7 +5576,7 @@ public class AssignmentAction extends PagedResourceActionII
 
 							// clean the ContentReview attributes
 							sEdit.setReviewIconUrl(null);
-							sEdit.setReviewScore(0); // default to be 0?
+							sEdit.setReviewScore(-2); // the default is -2 (e.g., for a new submission)
 							sEdit.setReviewStatus(null);
 
 							if (StringUtils.trimToNull(sEdit.getFeedbackFormattedText()) != null)


### PR DESCRIPTION
If a student re-submits, the displayed review score is reset to 0 (in ASSIGNMENT_SUBMISSION.xml) and the cron job which gets the new Turnitin score doesn't update this score (which is used in the UI) when it gets a new score for the new submission. Originally, the developer wasn't sure if it should be reset to 0 in this scenario and wrote:

sEdit.setReviewScore(0); // default to be 0?

The fix is that when a student resubmits, to reset the review score to -2, which is what it is set to for an initial submission and what it is assumed to be at various points in the logic, especially in BaseAssigmentService.getReviewScore().
