### PR TITLE
WL-4338 Fix bug of stack trace on submissions page.

### DIFF
--- a/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_list_submissions.vm
+++ b/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_list_submissions.vm
@@ -767,7 +767,7 @@
 										#if($allowReviewService && $assignment.getContent().AllowReviewService && $submission.isExternalGradeDifferent())
 											<span onclick="alert('$tlang.getFormattedMessage('review.conflicting.popup', $reviewServiceName)')" class="conflicting-assignment-mark">$submission.getGradeDisplay($typeOfGrade)!</span>
 										#else
-											$submission.getGradeDisplay($typeOfGrade)										
+											$submission.getGradeDisplay()
 										#end
 									#end
 								</td>


### PR DESCRIPTION
The problem is that on trunk there is a different method for getting the grades to 10.x and when the change in WL-4295 was ported back the method wasn’t updated. The wasn’t noticed until runtime as the templates aren’t compiled at all.
